### PR TITLE
Fix YAML template whitespace and quoting

### DIFF
--- a/templates/generic.yaml
+++ b/templates/generic.yaml
@@ -1,35 +1,35 @@
 workbook:
-{% if sheets | length %}
+{%- if sheets | length %}
   sheets:
-{% for sheetKey, sheet in sheets %}
-    - key: {{ sheetKey | dump }}
-      name: {{ sheet.name | dump }}
-{% set columnPairs = sheet.cols | dictsort -%}
-{% if columnPairs | length %}
+  {%- for sheetKey, sheet in sheets %}
+    - key: {{ sheetKey | dump | safe }}
+      name: {{ sheet.name | dump | safe }}
+    {%- set columnPairs = sheet.cols | dictsort %}
+    {%- if columnPairs | length %}
       columns:
-{% for column in columnPairs %}
-        - {{ column[0] | dump }}
-{% endfor %}
-{% else %}
+      {%- for column in columnPairs %}
+        - {{ column[0] | dump | safe }}
+      {%- endfor %}
+    {%- else %}
       columns: []
-{% endif %}
-{% if sheet.rows | length %}
+    {%- endif %}
+    {%- if sheet.rows | length %}
       rows:
-{% for row in sheet.rows %}
-{% set cells = row | dictsort -%}
-{% if cells | length %}
+      {%- for row in sheet.rows %}
+        {%- set cells = row | dictsort %}
+        {%- if cells | length %}
         -
-{% for cell in cells %}
-          {{ cell[0] }}: {{ cell[1] | dump }}
-{% endfor %}
-{% else %}
+          {%- for cell in cells %}
+          {{ cell[0] }}: {{ cell[1] | dump | safe }}
+          {%- endfor %}
+        {%- else %}
         - {}
-{% endif %}
-{% endfor %}
-{% else %}
+        {%- endif %}
+      {%- endfor %}
+    {%- else %}
       rows: []
-{% endif %}
-{% endfor %}
-{% else %}
+    {%- endif %}
+  {%- endfor %}
+{%- else %}
   sheets: []
-{% endif %}
+{%- endif %}


### PR DESCRIPTION
## Summary
- trim whitespace control markers in the generic YAML template to eliminate blank spacer lines in the rendered output
- mark dumped values as safe so double quotes render correctly instead of HTML entities

## Testing
- node - <<'NODE'
const nunjucks = require('nunjucks');
const fs = require('fs');
const path = require('path');
const tpl = fs.readFileSync(path.join('templates','generic.yaml'),'utf8');
const env = new nunjucks.Environment();
const sheets = {
  profile: {
    name: 'profile',
    cols: { Age: [50], Name: ['Onur'] },
    rows: [ { Age: 50, Name: 'Onur' } ]
  }
};
console.log(env.renderString(tpl, { sheets }));
NODE

------
https://chatgpt.com/codex/tasks/task_b_68cc529404e08328a39d2961cbebded2