### PR TITLE
Keep download controls on one row

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
         <div class="h-100">
           <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
             <h2 class="fs-5 mb-0">Output preview</h2>
-            <div class="ms-auto d-flex flex-wrap align-items-center gap-2">
+            <div class="ms-auto d-flex flex-nowrap align-items-center gap-2">
               <label for="outName" class="form-label mb-0 visually-hidden">Output file name</label>
               <input id="outName" type="text" class="form-control" value="document.yaml" style="min-width: 12rem;" />
               <button id="downloadBtn" class="btn btn-success" disabled>Download</button>


### PR DESCRIPTION
## Summary
- prevent the download controls from wrapping to multiple rows by using a no-wrap flex container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cce780b0d08328b7b00ff0492796cb